### PR TITLE
Restores compatibility with Rails 4.0

### DIFF
--- a/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
+++ b/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
@@ -31,10 +31,8 @@ module Hestia
           ActiveSupport::LegacyKeyGenerator.new(secret).generate_key(@options[:signed_cookie_salt])
         end
 
-        serializer = ActiveSupport::MessageEncryptor::NullSerializer
-
         # Finally, override @verifier with our own multi verifier containing all the secrets
-        @verifier = Hestia::MessageMultiVerifier.new(current_secret: active_secret, deprecated_secrets: deprecated_secrets, options: {serializer: serializer})
+        @verifier = Hestia::MessageMultiVerifier.new(current_secret: active_secret, deprecated_secrets: deprecated_secrets)
       end
     end
   end


### PR DESCRIPTION
Rails 4.0 still uses Marshal serialized cookies. When `NullSerializer` is chosen, the cookie content is not deserialized and exceptions are raised using a String where Rails thinks we have a Hash.

The intent is not to merge this, but just to use this branch while we're on Rails 4.0 in order to allow us to retain signed cookies and rotation, to re-evaluate when we upgrade to Rails 4.1.

Rails 4.0 support was removed in https://github.com/fac/hestia/pull/7.